### PR TITLE
fixed the issue with the preprocessing file missing when Start is pressed 

### DIFF
--- a/openpivgui.m
+++ b/openpivgui.m
@@ -439,7 +439,11 @@ outl = str2double(get(handles.edit_outl,'string'));
 
 preprocess = get(handles.checkbox_preprocess,'Value');
 if preprocess
-    prepfun = str2func(handles.preprocess);
+    if ~isfield(handles,'preprocess')
+        prepfun = inline('x');
+    else
+        prepfun = str2func(handles.preprocess);
+    end
 else
     prepfun = inline('x');
 end


### PR DESCRIPTION
Fixes issue: 
https://github.com/OpenPIV/openpiv-matlab/issues/5